### PR TITLE
Fixes issue with stale elements

### DIFF
--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -504,7 +504,11 @@ module Watir
         return
       end
 
-      @element = (@selector[:element] || locate)
+      begin
+        @element = (@selector[:element] || locate)
+      rescue Selenium::WebDriver::Error::StaleElementReferenceError
+        @element = nil
+      end
 
       unless @element
         raise UnknownObjectException, "unable to locate element, using #{selector_string}"


### PR DESCRIPTION
The way we've implemented our process page navigations sometimes results in stale element references when we check if they exist. This causes #exist? to return false when the element isn't actually there.
