### PR TITLE
Implements webdriver timeout methods

### DIFF
--- a/lib/watir-webdriver.rb
+++ b/lib/watir-webdriver.rb
@@ -19,6 +19,7 @@ require 'watir-webdriver/locators/child_row_locator'
 require 'watir-webdriver/locators/child_cell_locator'
 require 'watir-webdriver/browser'
 require 'watir-webdriver/screenshot'
+require 'watir-webdriver/timeouts'
 
 module Watir
   @always_locate = true

--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -35,6 +35,27 @@ module Watir
     end
 
     #
+    # Returns true if element does not exist.
+    # Immediately returns result without implicit waits when set
+    # For use when element is not expected to be there
+    #
+    # @return [Boolean]
+    #
+
+    def not_exists?
+      browser.without_implicit_wait do
+        begin
+          assert_exists
+          false
+        rescue UnknownObjectException, UnknownFrameException
+          true
+        end
+      end
+    end
+
+    alias_method :not_exist?, :not_exists?
+
+    #
     # Returns true if element exists.
     #
     # @return [Boolean]

--- a/lib/watir-webdriver/locators/element_locator.rb
+++ b/lib/watir-webdriver/locators/element_locator.rb
@@ -253,8 +253,6 @@ module Watir
       return if tag_name && !tag_name_matches?(element.tag_name.downcase, tag_name)
 
       element
-    rescue Selenium::WebDriver::Error::NoSuchElementError
-      nil
     end
 
     def all_elements

--- a/lib/watir-webdriver/timeouts.rb
+++ b/lib/watir-webdriver/timeouts.rb
@@ -1,0 +1,54 @@
+module Watir
+  class Timeouts
+
+    attr_reader :implicit_wait
+
+    def initialize(control)
+      @implicit_wait = 0
+      @control = control
+    end
+
+    #
+    # Calculates how long a Watir::Wait#until will take to execute based on combination of implicit and explicit waits
+    #
+
+    def expected_wait(explicit=nil, implicit=0)
+      explicit ||= Watir.default_timeout
+      if implicit == 0
+        explicit
+      else
+        2*implicit*((explicit-1)/(2*implicit) + 1)
+      end
+    end
+
+    #
+    # Set the amount of time the driver should wait when searching for elements.
+    #
+
+    def implicit_wait=(seconds)
+      seconds ||= 0
+      @control.timeouts.implicit_wait=(seconds)
+      @implicit_wait = seconds
+    end
+
+    #
+    # Sets the amount of time to wait for an asynchronous script to finish
+    # execution before throwing an error. If the timeout is negative, then the
+    # script will be allowed to run indefinitely.
+    #
+
+    def script_timeout=(seconds)
+      @control.timeouts.script_timeout=(seconds)
+    end
+
+    #
+    # Sets the amount of time to wait for a page load to complete before throwing an error.
+    # If the timeout is negative, page loads can be indefinite.
+    #
+
+    def page_load=(seconds)
+      @control.timeouts.page_load=(seconds)
+    end
+
+  end # Timeouts
+end # Watir

--- a/lib/watir-webdriver/wait.rb
+++ b/lib/watir-webdriver/wait.rb
@@ -117,8 +117,13 @@ module Watir
         raise NoMethodError, "undefined method `#{m}' for #{@element.inspect}:#{@element.class}"
       end
 
-      Watir::Wait.until(@timeout, @message) { @element.present? }
-
+      if @element.respond_to? :browser
+        @element.browser.without_implicit_wait do
+          Watir::Wait.until(@timeout, @message) { @element.present? }
+        end
+      else
+        Watir::Wait.until(@timeout, @message) { @element.present? }
+      end
       @element.__send__(m, *args, &block)
     end
   end # WhenPresentDecorator
@@ -149,8 +154,14 @@ module Watir
       message = "waiting for #{selector_string} to become present"
 
       if block_given?
-        Watir::Wait.until(timeout, message) { present? }
-        yield self
+        if self.respond_to? :browser
+          browser.without_implicit_wait do
+            Watir::Wait.until(timeout, message) { present? }
+            yield self
+          end
+        else
+          yield self
+        end
       else
         WhenPresentDecorator.new(self, timeout, message)
       end
@@ -171,7 +182,13 @@ module Watir
     def wait_until_present(timeout = nil)
       timeout ||= Watir.default_timeout
       message = "waiting for #{selector_string} to become present"
-      Watir::Wait.until(timeout, message) { present? }
+      if self.respond_to? :browser
+        browser.without_implicit_wait do
+          Watir::Wait.until(timeout, message) { present? }
+        end
+      else
+        Watir::Wait.until(timeout, message) { present? }
+      end
     end
 
     #

--- a/spec/convio_spec/element_spec.rb
+++ b/spec/convio_spec/element_spec.rb
@@ -30,4 +30,26 @@ describe "Element" do
       browser.legend(:text, "Personal information").previous_sibling.should be_nil
     end
   end
+
+  describe "#not_exists?" do
+    it "should not propagate ObsoleteElementErrors" do
+      browser.goto WatirSpec.url_for('removed_element.html', :needs_server => true)
+
+      button = browser.button(:id => "remove-button")
+      element = browser.div(:id => "text")
+
+      expect(element.not_exist?).to be false
+      button.click
+      expect(element.not_exist?).to be true
+    end
+
+    it "does not match only part of the class name" do
+      browser.goto(WatirSpec.url_for("class_locator.html"))
+      expect(browser.div(:class => "c").not_exist?).to be true
+    end
+
+    it "doesn't raise when called on nested elements" do
+      expect(browser.div(:id, 'no_such_div').link(:id, 'no_such_id').not_exist?).to be true
+    end
+  end
 end

--- a/spec/convio_spec/timeouts_spec.rb
+++ b/spec/convio_spec/timeouts_spec.rb
@@ -1,0 +1,82 @@
+require File.expand_path("../../watirspec/spec_helper", __FILE__)
+
+describe "Browser#timeouts" do
+
+  context "implicit waits" do
+    before do
+      browser.timeouts.implicit_wait = 0
+      browser.goto WatirSpec.url_for 'dynamic.html'
+    end
+
+    after { browser.timeouts.implicit_wait = 0 }
+
+    it "should store the implicit wait timeout" do
+      expect(browser.timeouts.implicit_wait).to be == 0
+    end
+
+    it "should store changes to the implicit wait timeout" do
+      browser.timeouts.implicit_wait = 3
+      expect(browser.timeouts.implicit_wait).to be == 3
+    end
+
+    it "should implicitly wait for a single element" do
+      browser.timeouts.implicit_wait = 3
+      browser.input(:id, 'adder').click
+      expect(browser.div(:id, 'box0')).to exist
+    end
+
+    it "should fail to find an element with implicit waits disabled" do
+      browser.timeouts.implicit_wait = 3
+      browser.timeouts.implicit_wait = 0
+      browser.input(:id, 'adder').click
+      expect(browser.div(:id, 'box0')).to_not exist
+    end
+
+    it "should fail to find an element with insufficient implicit wait" do
+      browser.timeouts.implicit_wait = 0.1
+      browser.input(:id, 'adder').click
+      expect(browser.div(:id, 'box0')).to_not exist
+    end
+
+    it "should implicitly wait until at least one element is found when searching for many" do
+      browser.timeouts.implicit_wait = 3
+      2.times { browser.input(:id, 'adder').click }
+      expect(browser.divs(:class_name, 'redbox').size).to be > 0
+    end
+
+    it "should fail to find any elements with insufficient implicit wait" do
+      browser.timeouts.implicit_wait = 0.1
+      2.times { browser.input(:id, 'adder').click }
+      expect(browser.divs(:class_name, 'redbox').size).to be == 0
+    end
+
+    it "should return after first attempt to find many after disabling implicit waits" do
+      browser.timeouts.implicit_wait = 3
+      browser.timeouts.implicit_wait = 0
+      browser.input(:id, 'adder').click
+      expect(browser.divs(:class_name, 'redbox').size).to be == 0
+    end
+  end
+
+  describe "execute async script" do
+    before {
+      browser.timeouts.script_timeout = 0
+      browser.goto WatirSpec.url_for("ajaxy_page.html")
+    }
+
+    it "should be able to return arrays of primitives from async scripts" do
+      result = browser.execute_async_script "arguments[arguments.length - 1]([null, 123, 'abc', true, false]);"
+      expect(result).to be == [nil, 123, 'abc', true, false]
+    end
+
+    it "should be able to pass multiple arguments to async scripts" do
+      result = browser.execute_async_script "arguments[arguments.length - 1](arguments[0] + arguments[1]);", 1, 2
+      expect(result).to be == 3
+    end
+
+    it "times out if the callback is not invoked" do
+      # Script is expected to be async and explicitly callback, so this should timeout.
+      expect { browser.execute_async_script "return 1 + 2;" }.to raise_error(Watir::Wait::TimeoutError)
+    end
+  end
+end

--- a/spec/convio_spec/wait_spec.rb
+++ b/spec/convio_spec/wait_spec.rb
@@ -1,0 +1,71 @@
+require File.expand_path("../../watirspec/spec_helper", __FILE__)
+
+describe "Implicit Waits" do
+  before(:each) { browser.timeouts.implicit_wait = 0 }
+
+  it "should wait the expected time to timeout for checking #exist? with both implicit and explicit waits set" do
+    explicit_wait = 5
+    implicit_wait = 6
+    expected_timeout = browser.timeouts.expected_wait(explicit_wait, implicit_wait)
+
+    browser.timeouts.implicit_wait = implicit_wait
+    start_time = Time.now
+    begin
+      Watir::Wait.until(explicit_wait) { browser.input(:id, 'not_here').exist? }
+    rescue Watir::Wait::TimeoutError
+      expect((Time.now - start_time).round).to be == expected_timeout
+    end
+  end
+
+  it "should ignore implicit wait when checking for #when_present without a block" do
+    explicit_wait = 1
+    implicit_wait = 6
+
+    browser.timeouts.implicit_wait = implicit_wait
+    start_time = Time.now
+    begin
+      browser.input(:id, 'not_here').when_present(explicit_wait).exists?
+    rescue Watir::Wait::TimeoutError
+      expect((Time.now - start_time).round).to be == explicit_wait
+    end
+  end
+
+  it "should ignore implicit wait when checking for #when_present with a block" do
+    explicit_wait = 1
+    implicit_wait = 6
+
+    browser.timeouts.implicit_wait = implicit_wait
+    start_time = Time.now
+    begin
+      browser.input(:id, 'not_here').when_present(explicit_wait) { |el| el.exists? }
+    rescue Watir::Wait::TimeoutError
+      expect((Time.now - start_time).round).to be == explicit_wait
+    end
+  end
+
+  it "should ignore implicit wait when checking for #wait_until_present" do
+    explicit_wait = 1
+    implicit_wait = 6
+
+    browser.timeouts.implicit_wait = implicit_wait
+    start_time = Time.now
+    begin
+      browser.input(:id, 'not_here').wait_until_present(explicit_wait).exists?
+    rescue Watir::Wait::TimeoutError
+      expect((Time.now - start_time).round).to be == explicit_wait
+    end
+  end
+
+  it "should ignore implicit wait when checking for #not_exists?" do
+    explicit_wait = 1
+    implicit_wait = 6
+
+    browser.timeouts.implicit_wait = implicit_wait
+    start_time = Time.now
+    begin
+      browser.input(:id, 'not_here').not_exists?
+    rescue Watir::Wait::TimeoutError
+      expect((Time.now - start_time).round).to be == explicit_wait
+    end
+  end
+end

--- a/spec/html/ajaxy_page.html
+++ b/spec/html/ajaxy_page.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<body>
+<form action="javascript:updateDom()">
+  <label for="typer">New label text:</label>
+  <input name="typer" type="text"/>
+  <br/>
+  <label for="color">Select label color:</label>
+  <input name="color" id="red" value="red" type="radio"/>Red
+  <input name="color" id="green" value="green" type="radio"/>Green
+  <br/>
+  <input name="submit" type="submit" value="Add Label"/>
+</form>
+<div id="update_butter" style="display:none"></div>
+<script>
+  var butter = document.getElementById('update_butter');
+
+  var textProperty = butter['innerText'] ? 'innerText' : 'textContent';
+
+  var listeners = [];
+  function registerListener(fn) {
+    listeners.push(fn);
+  }
+
+  function updateDom() {
+    butter.style.display = 'block';
+    butter[textProperty] = 'Updating';
+    disableForm();
+    tick();
+  }
+
+  function disableForm() {
+    var inputs = document.getElementsByTagName('input');
+    for (var i = 0, input; input = inputs[i]; ++i) {
+      input.disabled = true;
+    }
+  }
+
+  function enableForm() {
+    var inputs = document.getElementsByTagName('input');
+    for (var i = 0, input; input = inputs[i]; ++i) {
+      input.disabled = false;
+    }
+  }
+
+  function tick() {
+    var length = butter[textProperty].substring('Updating'.length).length;
+    if (length != 10) {
+      butter[textProperty] += '.';
+      window.setTimeout(tick, 500);
+    } else {
+      enableForm();
+      var div = document.createElement('div');
+      var colors = document.forms[0].color;
+      for (var i = 0, color; color = colors[i]; ++i) {
+        if (color.checked) {
+          div.style.backgroundColor = color.value;
+          break;
+        }
+      }
+      div[textProperty] = document.forms[0].typer.value;
+      div.className = 'label';
+      document.forms[0].typer.value = '';
+      document.body.appendChild(div);
+
+      butter[textProperty] = 'Done!';
+
+      window.setTimeout(function() {
+        while (listeners.length) {
+          try {
+            listeners.shift()(div[textProperty]);
+          } catch (e) {
+            butter[textProperty] = "Exception seen: " + e;
+          }
+        }
+      }, 500);
+    }
+  }
+</script>
+</body>
+</html>

--- a/spec/html/dynamic.html
+++ b/spec/html/dynamic.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+    "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+  <head>
+    <title></title>
+    <script type="text/javascript">
+      var next = 0;
+
+      function addMore() {
+        var box = document.createElement('DIV');
+        box.id = 'box' + next++;
+        box.className = 'redbox';
+        box.style.width = '150px';
+        box.style.height = '150px';
+        box.style.backgroundColor = 'red';
+        box.style.border = '1px solid black';
+        box.style.margin = '5px';
+
+        window.setTimeout(function() {
+          document.body.appendChild(box);
+        }, 1000);
+      }
+
+      function reveal() {
+        var elem = document.getElementById('revealed');
+        window.setTimeout(function() {
+          elem.style.display = '';
+        }, 1000);
+      }
+    </script>
+  </head>
+  <body>
+    <input id="adder" type="button" value="Add a box!" onclick="addMore()"/>
+
+    <input id="reveal" type="button" value="Reveal a new input" onclick="reveal();" />
+
+    <input id="revealed" style="display:none;" />
+  </body>
+</html>


### PR DESCRIPTION
These are options in selenium-webdriver, but haven't been encapsulated by watir-webdriver. I'm not sure why. If the intention is for this project to be a complete DSL, then I don't think we should ever need to reference driver in our tests.

I've liberally copied from selenium-webdriver in places (html files are exact copies). Do I need to do something special to maintain proper copyright/attribution?
