### PR TITLE
Fix handling of elements that go stale during lookup

### DIFF
--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -416,7 +416,7 @@ module Watir
 
     def present?
       exists? && visible?
-    rescue Selenium::WebDriver::Error::ObsoleteElementError, Selenium::WebDriver::Error::StaleElementReferenceError, UnknownObjectException
+    rescue Selenium::WebDriver::Error::ObsoleteElementError, UnknownObjectException
       # if the element disappears between the exists? and visible? calls,
       # consider it not present.
       false
@@ -504,14 +504,16 @@ module Watir
         return
       end
 
-      begin
-        @element = (@selector[:element] || locate)
-      rescue Selenium::WebDriver::Error::StaleElementReferenceError
-        @element = nil
-      end
+      @element = @selector[:element]
 
-      unless @element
-        raise UnknownObjectException, "unable to locate element, using #{selector_string}"
+      if @element
+        assert_not_stale
+      else
+        @element = locate
+
+        unless @element
+          raise UnknownObjectException, "unable to locate element, using #{selector_string}"
+        end
       end
     end
 

--- a/lib/watir-webdriver/locators/element_locator.rb
+++ b/lib/watir-webdriver/locators/element_locator.rb
@@ -39,7 +39,7 @@ module Watir
       # It is also used to alter behavior of methods locating more than one type of element
       # (e.g. text_field locates both input and textarea)
       validate_element(element) if element
-    rescue Selenium::WebDriver::Error::NoSuchElementError
+    rescue Selenium::WebDriver::Error::NoSuchElementError, Selenium::WebDriver::Error::ObsoleteElementError
       nil
     end
 

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -31,9 +31,11 @@ describe Watir::Element do
   end
 
   describe "#exists?" do
-    it "should not propagate ObsoleteElementErrors" do
+    before do
       browser.goto WatirSpec.url_for('removed_element.html', :needs_server => true)
+    end
 
+    it "should not propagate ObsoleteElementErrors" do
       button  = browser.button(:id => "remove-button")
       element = browser.div(:id => "text")
 
@@ -41,6 +43,26 @@ describe Watir::Element do
       button.click
       expect(element).to_not exist
     end
+
+    it "should determine if element constructed with WebDriver element is stale" do
+      button = browser.button(:id => "remove-button")
+      text   = browser.element(:element, browser.div(:id => "text").wd)
+
+      expect(text).to exist
+      button.click
+      expect(text).to_not exist
+    end
+
+    it "should handle element that becomes stale during lookup" do
+      wd_element = browser.div(:id => "text").wd
+
+      # simulate element going stale during lookup
+      allow(browser.driver).to receive(:find_element).with(:id, 'text') { wd_element }
+      browser.refresh
+
+      expect(browser.div(:id, 'text')).to_not exist
+    end
+
   end
 
   describe "#hover" do


### PR DESCRIPTION
This pulls in the changes that Jari made to my code in the watir/watir-webdriver repo. He changed where the error capture happened, and I think it is better than where I put it.

(cherry picked from commit a9a2360)
