### PR TITLE
Add support for specifying explicit wait polling interval

### DIFF
--- a/spec/convio_spec/wait_spec.rb
+++ b/spec/convio_spec/wait_spec.rb
@@ -1,0 +1,55 @@
+# encoding: utf-8
+require File.expand_path("../../watirspec/spec_helper", __FILE__)
+
+describe Watir::Wait do
+
+  describe "interval" do
+    it "uses default interval" do
+      interval_count = 0
+      begin
+        Wait.until(1) { interval_count+=1; false }
+      rescue Watir::Wait::TimeoutError
+        interval_count.should == 10
+      end
+    end
+
+    it "changes default interval" do
+      interval_count = 0
+      begin
+        Wait.retry_every(0.5).until(1) { interval_count+=1; false }
+      rescue Watir::Wait::TimeoutError
+        interval_count.should == 2
+      end
+    end
+
+    it "restores default interval after #until" do
+      begin
+        Wait.retry_every(0.5).until(1) { false }
+      rescue Watir::Wait::TimeoutError
+      end
+
+      interval_count = 0
+      begin
+        Wait.until(1) { interval_count+=1; false }
+      rescue Watir::Wait::TimeoutError
+        interval_count.should == 10
+      end
+    end
+
+    it "restores default interval after #while" do
+      begin
+        Wait.retry_every(0.5).while(1) { true }
+      rescue Watir::Wait::TimeoutError
+      end
+
+      interval_count = 0
+      begin
+        Wait.while(1) { interval_count+=1; true }
+      rescue Watir::Wait::TimeoutError
+        interval_count.should == 10
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
Selenium WebDriver implements the Wait class by instantiating a new Wait object with optional parameters for setting timeout, message and polling interval. In Watir WebDriver the first two are passed into a class method, and the polling interval is hard coded as a constant.

This seems like the easiest way to temporarily change the polling interval without re-implementing the entire Watir Wait class.
