### PR TITLE
Remove redundant Button#locate override

### DIFF
--- a/lib/watir-webdriver/elements/button.rb
+++ b/lib/watir-webdriver/elements/button.rb
@@ -49,11 +49,9 @@ module Watir
 
     private
 
-    def locate
-      @parent.assert_exists
-      ButtonLocator.new(@parent.wd, @selector, self.class.attribute_list).locate
+    def locator_class
+      ButtonLocator
     end
-
   end # Button
 
   class ButtonCollection < ElementCollection


### PR DESCRIPTION
(cherry picked from commit aae09af)
Another improvement pulled from watir/watir-webdriver
